### PR TITLE
xaml2cs: Always use InvariantCulture

### DIFF
--- a/xaml2cs/xaml2cs.cs
+++ b/xaml2cs/xaml2cs.cs
@@ -1,12 +1,16 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Threading;
 using System.Xml;
 
 class Xaml2Cs
 {
 	public Xaml2Cs ()
 	{
+		Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+
 		types = new Dictionary<string,XamlType>();
 
 		types["AnimationTimeline"] = new XamlType("System.Windows.Media.Animation", "AnimationTimeline");


### PR DESCRIPTION
Some cultures use "," instead of "." for the decimal separator. This
caused some errors in Double parsing and formatting.