### PR TITLE
"Stub" the implementation for different TextRun types

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Managed/TextFormatting/FullTextLine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Managed/TextFormatting/FullTextLine.cs
@@ -396,6 +396,24 @@ namespace Managed.TextFormatting
 					// Default should be empty
 					return result;
 				}
+				else if (textRun is TextModifier)
+				{
+					var result = new TextMetrics();
+					// Default should be empty
+					return result;
+				}
+				else if (textRun is TextEmbeddedObject)
+				{
+					var result = new TextMetrics();
+					// Default should be empty
+					return result;
+				}
+				else if (textRun is TextEndOfSegment)
+				{
+					var result = new TextMetrics();
+					// Default should be empty
+					return result;
+				}
 				else
 				{
 					throw new NotImplementedException(String.Format("Managed.TextFormatting.FullTextLine.GetRunMetrics for {0}", textRun.GetType().FullName));
@@ -519,6 +537,18 @@ namespace Managed.TextFormatting
 						origin.X += formatted.Width;
 					}
 					else if (ordered.TextRun is TextHidden)
+					{
+						// Nothing to do.
+					}
+					else if (ordered.TextRun is TextModifier)
+					{
+						// Nothing to do.
+					}
+					else if (ordered.TextRun is TextEmbeddedObject)
+					{
+						// Nothing to do.
+					}
+					else if (ordered.TextRun is TextEndOfSegment)
 					{
 						// Nothing to do.
 					}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MarshalLocal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MarshalLocal.cs
@@ -11,6 +11,7 @@ namespace System.Runtime.InteropServices
         {
             try
             {
+                return true;
                 int unused = Marshal.GetStartComSlot(type);
             }
             catch (ArgumentException)


### PR DESCRIPTION
This is one of the hacks I put in place to get the Elite Dangerous launcher working. This one in particular fixed the issue when trying to manually login.

I actually just copy and pasted your code for TextHidden. This worked for Elite Dangerous, but may of course not work for something else.

I guess each of those 'if' statements are kind of like a stub. I should probably have commented as such (instead of also copying your comments).

I'm of course happy to change the comments in this, or put everything in to the one big 'if' statement if that's your preference.

In fact, if it's quicker and/or easier for you, I'm happy for you to reject this pull request and do your own thing in your own time.