### PR TITLE
PresentationFramework: Suppress invalid operation exception when incompatible binding is used with readonly property.

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/PropertyPathWorker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/PropertyPathWorker.cs
@@ -1616,7 +1616,7 @@ namespace MS.Internal.Data
 
             if (pi != null)
             {
-                if (IsPropertyReadOnly(item, pi))
+                if (IsPropertyReadOnly(item, pi) && !FrameworkAppContextSwitches.AllowTwoWayBindingOnNonPublicSetter)
                     throw new InvalidOperationException(SR.Get(SRID.CannotWriteToReadOnly, item.GetType(), pi.Name));
             }
             else if (pd != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkAppContextSwitches.cs
@@ -129,6 +129,17 @@ namespace MS.Internal
                 return LocalAppContext.GetCachedSwitchValue(ItemAutomationPeerKeepsItsItemAliveSwitchName, ref _ItemAutomationPeerKeepsItsItemAlive);
             }
         }
+
+        internal const string AllowTwoWayBindingOnNonPublicSetterSwitchName = "Switch.System.Windows.Data.Binding.AllowTwoWayBindingOnNonPublicSetter";
+        private static int _AllowTwoWayBindingOnNonPublicSetter;
+        public static bool AllowTwoWayBindingOnNonPublicSetter
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return LocalAppContext.GetCachedSwitchValue(AllowTwoWayBindingOnNonPublicSetterSwitchName, ref _AllowTwoWayBindingOnNonPublicSetter);
+            }
+        }
     }
 
 #pragma warning restore 436

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/AppContextDefaultValues.cs
@@ -31,6 +31,10 @@ namespace System
             {
                 case ".NETFramework":
                     {
+                        if (targetFrameworkVersion == 40500)
+                        {
+                            LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.AllowTwoWayBindingOnNonPublicSetterSwitchName, true);
+                        }
                         if (targetFrameworkVersion <= 40502)
                         {
                             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.DoNotApplyLayoutRoundingToMarginsAndBorderThicknessSwitchName, true);
@@ -73,6 +77,8 @@ namespace System
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.AppendLocalAssemblyVersionForSourceUriSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.KeyboardNavigationFromHyperlinkInItemsControlIsNotRelativeToFocusedElementSwitchName, false);
             LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.ItemAutomationPeerKeepsItsItemAliveSwitchName, false);
+
+            LocalAppContext.DefineSwitchDefault(FrameworkAppContextSwitches.AllowTwoWayBindingOnNonPublicSetterSwitchName, false);
 
             // UseAdornerForTextboxSelectionRenderingSwitchName is always true, i.e., disabled by default. 
             // Do not initialized this again - this was initialized earlier in PopulateDefaultValuesPartial unconditionally.


### PR DESCRIPTION
Only applied when targeting 4.5.

Fixes exceptions with DayZ launcher.