### PR TITLE
dwritewrapper: Fix offset used by GetTextAtPosition().

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/TextAnalyzerSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/TextAnalyzerSource.cs
@@ -103,7 +103,7 @@ namespace MS.Internal.Text.TextInterface
 			if (FindSegmentAtPosition(position, out index))
 			{
 				var segment = TextSegments[index];
-				text = IntPtr.Add(segment.ptr, (int)(position - segment.start));
+				text = IntPtr.Add(segment.ptr, (int)(position - segment.start) * 2);
 				text_len = segment.end - position;
 			}
 			else


### PR DESCRIPTION
Signed-off-by: Nikolay Sivov <nsivov@codeweavers.com>